### PR TITLE
fix: update Python versions in CI workflows

### DIFF
--- a/.devcontainer/apt-packages.txt
+++ b/.devcontainer/apt-packages.txt
@@ -1,3 +1,8 @@
+ca-certificates=20240203
+python3=3.12.3-0ubuntu2
+python3-dev=3.12.3-0ubuntu2
+python3-pip=24.0+dfsg-1ubuntu1.1
+python3-venv=3.12.3-0ubuntu2
 python3-apt=2.7.7ubuntu4
 python3-tqdm=4.66.2-2
 python3-requests=2.31.0+dfsg-1ubuntu1

--- a/.devcontainer/apt-packages.txt
+++ b/.devcontainer/apt-packages.txt
@@ -1,8 +1,3 @@
-ca-certificates=20240203
-python3=3.12.3-0ubuntu2
-python3-dev=3.12.3-0ubuntu2
-python3-pip=24.0+dfsg-1ubuntu1.1
-python3-venv=3.12.3-0ubuntu2
 python3-apt=2.7.7ubuntu4
 python3-tqdm=4.66.2-2
 python3-requests=2.31.0+dfsg-1ubuntu1

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -12,13 +12,12 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -12,16 +12,22 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
 
     steps:
       - name: Checkout code

--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -4,6 +4,7 @@ import time
 import apt
 import logging
 from tqdm import tqdm
+from typing import List, Tuple
 
 from .. import GitHubIssue, is_root
 
@@ -16,7 +17,7 @@ def run_apt_update() -> apt.Cache:
 
     return cache
 
-def get_apt_full_upgrade_target(cache) -> tuple:
+def get_apt_full_upgrade_target(cache) -> Tuple[apt.Cache, List[apt.Package], List[apt.Package], List[apt.Package]]:
     cache.upgrade(dist_upgrade=True)
 
     changes = cache.get_changes()
@@ -38,7 +39,7 @@ def run_apt_full_upgrade() -> bool:
         logger.error(f"An error occurred during the upgrade: {e}")
         return False
 
-def post_github_comment(github_issue: GitHubIssue, hostname: str, to_upgrade: list[apt.Package], to_install: list[apt.Package], to_remove: list[apt.Package]) -> None:
+def post_github_comment(github_issue: GitHubIssue, hostname: str, to_upgrade: List[apt.Package], to_install: List[apt.Package], to_remove: List[apt.Package]) -> None:
     # Update the issue body with the upgrade information
     comment_body = textwrap.dedent("""
     ## {markdown_computer_name} : apt upgrade


### PR DESCRIPTION
- Remove unused Python packages from apt-packages.txt
- Adjust Python version matrix for Linux CI
- Ensure Windows CI includes Python 3.8 in the version matrix