### PR TITLE
fix: update CI workflows for Linux and Windows

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -39,7 +37,7 @@ jobs:
           python3 -m unittest discover -s src/linux -p "test_*.py"
 
   check-finished:
-    name: Check finished CI
+    name: Check finished CI for Linux
     runs-on: ubuntu-latest
     if: always()
     needs:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -39,7 +39,7 @@ jobs:
           python -m unittest discover -s src/windows -p "test_*.py"
 
   check-finished:
-    name: Check finished CI
+    name: Check finished CI for Windows
     runs-on: ubuntu-latest
     if: always()
     needs:

--- a/src/windows/test_update_scoop_softwares.py
+++ b/src/windows/test_update_scoop_softwares.py
@@ -128,8 +128,9 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
         mp.terminate.assert_called()
 
     @patch('src.windows.update_scoop_softwares.os.getenv')
-    @patch('src.windows.update_scoop_softwares.os.startfile')
-    def test_start_app(self, mock_startfile, mock_getenv):
+    @patch('src.windows.update_scoop_softwares.os.path.exists', return_value=True)
+    @patch('src.windows.update_scoop_softwares.subprocess.Popen')
+    def test_start_app(self, mock_popen, mock_exists, mock_getenv):
         with tempfile.TemporaryDirectory() as tmpdir:
             mock_getenv.return_value = tmpdir
             # create apps/app1/current/app.exe
@@ -138,8 +139,8 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
             exe = app_path / 'app.exe'
             exe.write_text('')
             start_app('app1', [{'name': 'app.exe'}])
-            # os.startfile should be called with a Path object
-            mock_startfile.assert_called_with(exe)
+            # subprocess.Popen should be called with the exe path
+            mock_popen.assert_called_with([exe], stdout=unittest.mock.ANY, stderr=unittest.mock.ANY)
 
 
 if __name__ == '__main__':

--- a/src/windows/test_update_scoop_softwares.py
+++ b/src/windows/test_update_scoop_softwares.py
@@ -140,7 +140,7 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
             exe.write_text('')
             start_app('app1', [{'name': 'app.exe'}])
             # subprocess.Popen should be called with the exe path
-            mock_popen.assert_called_with([exe], stdout=unittest.mock.ANY, stderr=unittest.mock.ANY)
+            mock_popen.assert_called_with([str(exe)], stdout=unittest.mock.ANY, stderr=unittest.mock.ANY)
 
 
 if __name__ == '__main__':

--- a/src/windows/test_update_scoop_softwares.py
+++ b/src/windows/test_update_scoop_softwares.py
@@ -140,7 +140,7 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
             exe.write_text('')
             start_app('app1', [{'name': 'app.exe'}])
             # subprocess.Popen should be called with the exe path
-            mock_popen.assert_called_with([str(exe)], stdout=unittest.mock.ANY, stderr=unittest.mock.ANY)
+            mock_popen.assert_called_with([exe], stdout=unittest.mock.ANY, stderr=unittest.mock.ANY)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Remove unused Python version setup in Linux CI
- Rename CI job names for clarity
- Update test_start_app to use subprocess.Popen instead of os.startfile