### PR TITLE
fix: update_software_update_rowで最新のissue bodyを取得するように修正

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -35,6 +35,10 @@ class GitHubIssue:
 
     checkmark = self.status_mapping[status]
 
+    # 最新のissue bodyを取得してself.software_updatesを更新
+    self.body = self.__get_issue_body()
+    self.software_updates = self.__get_software_update_rows()
+
     for software_update in self.software_updates:
       if software_update["computer_name"] == computer_name and software_update["package_manager"] == package_manager:
         software_update["markdown"]["checkmark"] = checkmark


### PR DESCRIPTION
## 概要
Issue #19 の対応

複数のマシンで同時にアップデートを実行した場合、他のマシンのステータスが無視される問題を修正

## 変更内容
- `update_software_update_row`メソッドの最初で最新のissue bodyを取得するように修正
- `self.body = self.__get_issue_body()`と`self.software_updates = self.__get_software_update_rows()`を追加
- これにより、他のマシンが更新した内容も反映されるようになります

## テスト内容
- Python構文チェックを実行し、エラーがないことを確認

## チェックリスト
- [x] 構文チェックが通ることを確認
- [x] Issue要件を満たしていることを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>