### PR TITLE
fix: cleanup_scoop() の終了コード確認とテストを追加

### DIFF
--- a/src/windows/update_scoop_softwares.py
+++ b/src/windows/update_scoop_softwares.py
@@ -306,7 +306,12 @@ def cleanup_scoop() -> bool:
     ]
     success = True
     for command in commands:
-        result = subprocess.run(command, capture_output=True, text=True)
+        try:
+            result = subprocess.run(command, capture_output=True, text=True)
+        except OSError as e:
+            success = False
+            logger.error(f"Command failed: {' '.join(command)} ({e})")
+            continue
         if result.returncode != 0:
             success = False
             logger.error(f"Command failed: {' '.join(command)} (exit code {result.returncode})")

--- a/src/windows/update_scoop_softwares.py
+++ b/src/windows/update_scoop_softwares.py
@@ -294,9 +294,25 @@ def start_app(app_name, app_processes):
         except Exception as e:
             print(f"Failed to start {exe_path_str}: {e}")
 
-def cleanup_scoop():
-    os.system("scoop cleanup *")
-    os.system("scoop cache rm *")
+def cleanup_scoop() -> bool:
+    """scoop のクリーンアップとキャッシュ削除を実行する。
+
+    Returns:
+        bool: すべてのコマンドが正常終了した場合は True、いずれかが失敗した場合は False。
+    """
+    commands = [
+        ["scoop", "cleanup", "*"],
+        ["scoop", "cache", "rm", "*"],
+    ]
+    success = True
+    for command in commands:
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            success = False
+            logger.error(f"Command failed: {' '.join(command)} (exit code {result.returncode})")
+            if result.stderr:
+                logger.error(f"stderr: {result.stderr}")
+    return success
 
 def run(github_issue, hostname) -> None:
     try:
@@ -369,7 +385,7 @@ def run(github_issue, hostname) -> None:
             os_eol_critical=is_critical,
         )
 
-        # Cleanup scoop
+        # scoop のクリーンアップを実行
         cleanup_scoop()
 
         upgraded_status_results = get_scoop_status()

--- a/tests/windows/test_update_scoop_softwares.py
+++ b/tests/windows/test_update_scoop_softwares.py
@@ -355,6 +355,13 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
     self.assertFalse(result)
     self.assertEqual(mock_run.call_count, 2)
 
+  @patch('src.windows.update_scoop_softwares.subprocess.run', side_effect=OSError('scoop not found'))
+  def test_cleanup_scoop_command_not_found(self, mock_run):
+    # scoop コマンドが PATH で解決できない場合でも例外を送出せず False を返す
+    result = cleanup_scoop()
+    self.assertFalse(result)
+    self.assertEqual(mock_run.call_count, 2)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/windows/test_update_scoop_softwares.py
+++ b/tests/windows/test_update_scoop_softwares.py
@@ -14,6 +14,7 @@ from src.windows.update_scoop_softwares import (
   stop_app,
   start_app,
   get_app_startup_command,
+  cleanup_scoop,
 )
 
 
@@ -337,6 +338,22 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
       exe_path, args = get_app_startup_command('app1', 'test.exe')
       self.assertIsNone(exe_path)
       self.assertIsNone(args)
+
+  @patch('src.windows.update_scoop_softwares.subprocess.run')
+  def test_cleanup_scoop_success(self, mock_run):
+    mock_run.return_value = MagicMock(returncode=0, stderr='')
+    result = cleanup_scoop()
+    self.assertTrue(result)
+    self.assertEqual(mock_run.call_count, 2)
+    mock_run.assert_any_call(['scoop', 'cleanup', '*'], capture_output=True, text=True)
+    mock_run.assert_any_call(['scoop', 'cache', 'rm', '*'], capture_output=True, text=True)
+
+  @patch('src.windows.update_scoop_softwares.subprocess.run')
+  def test_cleanup_scoop_failure(self, mock_run):
+    mock_run.return_value = MagicMock(returncode=1, stderr='error')
+    result = cleanup_scoop()
+    self.assertFalse(result)
+    self.assertEqual(mock_run.call_count, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概要

PR #59 (#59) の Copilot レビューで指摘された未解決の 3 件に対応する。

## 対応内容

- `cleanup_scoop()` を `os.system` から `subprocess.run` に変更し、各コマンドの終了コード / stderr を確認して `logger.error` に記録するようにした
  - 失敗がサイレントになる問題を解消
  - リスト引数で渡すため `*` も確実に引数として渡される
- `cleanup_scoop()` 呼び出し箇所のコメントを日本語化 (`# Cleanup scoop` → `# scoop のクリーンアップを実行`)
- `cleanup_scoop()` が 2 つのコマンド (`scoop cleanup *`, `scoop cache rm *`) を実行することを検証するユニットテストを追加

## 判断記録

- 判断内容: `os.system` を `subprocess.run` に置き換え、戻り値ベースで成功可否を判定する形にした
- 検討した代替案: `shell=True` で文字列コマンドとして実行する案
- 不採用の理由: リポジトリ内の他モジュール (`src/linux/update_apt_softwares.py`) が `subprocess.run` にリスト引数 + `capture_output=True` を使う一貫したパターンを採っており、それに合わせた方が保守性が高いため
- 前提・仮定: `scoop` コマンドは Windows 環境の PATH 上で解決可能であり、`shell=False` でも `subprocess.run(["scoop", ...])` が既存の `os.system("scoop update")` 呼び出し (同ファイル内、変更なし) と同様に機能する前提。Windows 実機での動作確認は未実施
- 他エージェントによるレビュー可否: 可 (Codex/Gemini でのレビュー未実施)

## テスト

- `pytest tests/windows/test_update_scoop_softwares.py` — 23 件全て pass