### PR TITLE
fix: cleanup_scoop() のsubprocess呼び出しにshell=Trueを追加

### DIFF
--- a/src/windows/update_scoop_softwares.py
+++ b/src/windows/update_scoop_softwares.py
@@ -310,7 +310,7 @@ def cleanup_scoop() -> bool:
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
         except OSError as e:
             success = False
-            logger.error(f"Command failed: {' '.join(command)} ({e})")
+            logger.error(f"Command failed to launch via cmd.exe (shell=True): {' '.join(command)} ({e})")
             continue
         if result.returncode != 0:
             success = False

--- a/src/windows/update_scoop_softwares.py
+++ b/src/windows/update_scoop_softwares.py
@@ -307,7 +307,7 @@ def cleanup_scoop() -> bool:
     success = True
     for command in commands:
         try:
-            result = subprocess.run(command, capture_output=True, text=True)
+            result = subprocess.run(command, shell=True, capture_output=True, text=True)
         except OSError as e:
             success = False
             logger.error(f"Command failed: {' '.join(command)} ({e})")

--- a/tests/windows/test_update_scoop_softwares.py
+++ b/tests/windows/test_update_scoop_softwares.py
@@ -357,7 +357,8 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
 
   @patch('src.windows.update_scoop_softwares.subprocess.run', side_effect=OSError('scoop not found'))
   def test_cleanup_scoop_command_not_found(self, mock_run):
-    # scoop コマンドが PATH で解決できない場合でも例外を送出せず False を返す
+    # shell=True 経由でも cmd.exe 自体の起動失敗等で OSError が送出される場合があり、
+    # その際も例外を送出せず False を返す (scoop 自体が見つからない場合は returncode != 0 として test_cleanup_scoop_failure と同じ経路になる)
     result = cleanup_scoop()
     self.assertFalse(result)
     self.assertEqual(mock_run.call_count, 2)

--- a/tests/windows/test_update_scoop_softwares.py
+++ b/tests/windows/test_update_scoop_softwares.py
@@ -345,8 +345,8 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
     result = cleanup_scoop()
     self.assertTrue(result)
     self.assertEqual(mock_run.call_count, 2)
-    mock_run.assert_any_call(['scoop', 'cleanup', '*'], capture_output=True, text=True)
-    mock_run.assert_any_call(['scoop', 'cache', 'rm', '*'], capture_output=True, text=True)
+    mock_run.assert_any_call(['scoop', 'cleanup', '*'], shell=True, capture_output=True, text=True)
+    mock_run.assert_any_call(['scoop', 'cache', 'rm', '*'], shell=True, capture_output=True, text=True)
 
   @patch('src.windows.update_scoop_softwares.subprocess.run')
   def test_cleanup_scoop_failure(self, mock_run):

--- a/tests/windows/test_update_scoop_softwares.py
+++ b/tests/windows/test_update_scoop_softwares.py
@@ -355,8 +355,8 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
     self.assertFalse(result)
     self.assertEqual(mock_run.call_count, 2)
 
-  @patch('src.windows.update_scoop_softwares.subprocess.run', side_effect=OSError('scoop not found'))
-  def test_cleanup_scoop_command_not_found(self, mock_run):
+  @patch('src.windows.update_scoop_softwares.subprocess.run', side_effect=OSError('cmd.exe not found'))
+  def test_cleanup_scoop_cmd_exe_launch_failure(self, mock_run):
     # shell=True 経由でも cmd.exe 自体の起動失敗等で OSError が送出される場合があり、
     # その際も例外を送出せず False を返す (scoop 自体が見つからない場合は returncode != 0 として test_cleanup_scoop_failure と同じ経路になる)
     result = cleanup_scoop()


### PR DESCRIPTION
## 概要

Windows 環境で `cleanup_scoop()` が `WinError 2` (指定されたファイルが見つかりません) で失敗する不具合を修正する。

## 原因

`src/windows/update_scoop_softwares.py` の `cleanup_scoop()` は `subprocess.run` を `shell=True` なしで呼び出している。Windows の `CreateProcess` (shell=False 時の実行経路) は拡張子なしのコマンド名 (`scoop`) に対して `PATHEXT` 環境変数による拡張子解決を行わないため、scoop の shim を解決できず `WinError 2` になる。

同ファイル内の他の scoop 呼び出し (`os.system`/`os.popen`) は `cmd.exe` 経由のため `PATHEXT` 解決が効いており、この問題は発生しない。

## 修正内容

- `cleanup_scoop()` 内の `subprocess.run` 呼び出しに `shell=True` を追加し、同ファイル内の他の scoop 呼び出しと解決方式を統一
- `test_cleanup_scoop_success` のアサーションを `shell=True` を含む形に更新
- `test_cleanup_scoop_command_not_found` のコメントを、`shell=True` 適用後の実際の挙動 (scoop 未検出時は returncode != 0 の経路になる) に合わせて修正

## テスト

`pytest tests/windows` で 24件全て PASS を確認済み。

## 前提条件・仮定・不確実性

- 本セッションは Linux 環境のため、実機 (Windows + scoop インストール済み環境) での動作確認は実施していない。コードレビューとユニットテストによる検証に留まる。

Closes #65

Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/6029489/Spec+-+Issue+65+cleanup_scoop+WinError+2
Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/5898348/Plan+-+Issue+65+cleanup_scoop+WinError+2