### PR TITLE
fix: dpkg の中断状態を検出し dpkg --configure -a を自動実行する

### DIFF
--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -51,8 +51,7 @@ def is_dpkg_broken() -> bool:
 def run_dpkg_configure() -> bool:
   """dpkg --configure -a を実行し、未完了のパッケージ設定を修復する。
 
-  既存の run_apt_full_upgrade() と同じスタイル (os.system + 例外握り +
-  bool 返却) に合わせている。
+  既存の apt 実行処理のスタイルに合わせている。
 
   Returns:
       bool: 終了コードが 0 であれば True、それ以外または例外発生時は False。

--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -25,6 +25,29 @@ def _is_installed_version(value):
   return normalized not in ("not installed", "not-installed", "none", "unknown")
 
 
+def is_dpkg_broken() -> bool:
+  """dpkg が中断状態 (dpkg --configure -a が必要な状態) かどうかを判定する。
+
+  dpkg --audit は破損パッケージが存在しなくても終了コード 0 を返すため、
+  check=True は使わず標準出力の有無のみで判定する。
+
+  Returns:
+      bool: 中断状態であれば True、正常であれば False。
+          dpkg --audit の実行自体が失敗した場合も False を返す
+          (検出ロジックの不備で apt 更新処理本体を止めないため)。
+  """
+  try:
+    result = subprocess.run(
+      ["dpkg", "--audit"],
+      text=True,
+      capture_output=True,
+    )
+  except OSError as e:
+    logger.warning("Failed to run dpkg --audit: %s", e)
+    return False
+  return bool(result.stdout.strip())
+
+
 def _log_apt_stderr(stderr, context):
   if not stderr:
     return

--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -267,6 +267,29 @@ def run(github_issue, hostname):
       os_eol_critical=is_critical,
     )
 
+    if is_dpkg_broken():
+      logger.warning("dpkg is in an interrupted state; running dpkg --configure -a...")
+      if run_dpkg_configure():
+        logger.info("dpkg --configure -a completed successfully.")
+        github_issue.comment(
+          f"{github_issue.get_markdown_computer_name(hostname)} : dpkg の中断状態を検出したため `dpkg --configure -a` を実行しました。"
+        )
+      else:
+        logger.error("dpkg --configure -a failed.")
+        github_issue.comment(
+          f"{github_issue.get_markdown_computer_name(hostname)} : dpkg の中断状態を検出し `dpkg --configure -a` を実行しましたが失敗しました。手動対応が必要です。"
+        )
+        github_issue.atomic_update_with_retry(
+          computer_name=hostname,
+          package_manager="apt",
+          upgraded="",
+          failed="1",
+          status="failed",
+          os_eol=os_eol_info,
+          os_eol_critical=is_critical,
+        )
+        return
+
     logger.info("Updating package list...")
     run_apt_update()
     _, to_upgrade, to_install, to_remove = get_apt_full_upgrade_target()

--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -45,6 +45,9 @@ def is_dpkg_broken() -> bool:
   except OSError as e:
     logger.warning("Failed to run dpkg --audit: %s", e)
     return False
+  if result.returncode != 0:
+    logger.warning("dpkg --audit exited with a non-zero status: %s", result.returncode)
+    return False
   return bool(result.stdout.strip())
 
 
@@ -60,7 +63,7 @@ def run_dpkg_configure() -> bool:
     result = os.system("dpkg --configure -a")
     return result == 0
   except Exception as e:
-    logger.error(f"An error occurred while running dpkg --configure -a: {e}")
+    logger.error("An error occurred while running dpkg --configure -a: %s", e)
     return False
 
 

--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -48,6 +48,23 @@ def is_dpkg_broken() -> bool:
   return bool(result.stdout.strip())
 
 
+def run_dpkg_configure() -> bool:
+  """dpkg --configure -a を実行し、未完了のパッケージ設定を修復する。
+
+  既存の run_apt_full_upgrade() と同じスタイル (os.system + 例外握り +
+  bool 返却) に合わせている。
+
+  Returns:
+      bool: 終了コードが 0 であれば True、それ以外または例外発生時は False。
+  """
+  try:
+    result = os.system("dpkg --configure -a")
+    return result == 0
+  except Exception as e:
+    logger.error(f"An error occurred while running dpkg --configure -a: {e}")
+    return False
+
+
 def _log_apt_stderr(stderr, context):
   if not stderr:
     return

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 from subprocess import CalledProcessError
 import os
 
-from src.linux.update_apt_softwares import is_root, run_apt_update, get_apt_full_upgrade_target, run_apt_full_upgrade, _is_installed_version, is_dpkg_broken
+from src.linux.update_apt_softwares import is_root, run_apt_update, get_apt_full_upgrade_target, run_apt_full_upgrade, _is_installed_version, is_dpkg_broken, run_dpkg_configure
 
 class TestUpdateAptSoftwares(unittest.TestCase):
   # 正常系: root権限での実行確認
@@ -259,6 +259,30 @@ class TestUpdateAptSoftwares(unittest.TestCase):
 
     self.assertFalse(is_dpkg_broken())
     mock_logger.warning.assert_called_once()
+
+  # 正常系: dpkg --configure -a の実行成功
+  @patch("os.system")
+  def test_run_dpkg_configure_success(self, mock_system):
+    mock_system.return_value = 0
+
+    self.assertTrue(run_dpkg_configure())
+    mock_system.assert_called_once_with("dpkg --configure -a")
+
+  # 異常系: dpkg --configure -a の実行失敗
+  @patch("os.system")
+  def test_run_dpkg_configure_failure(self, mock_system):
+    mock_system.return_value = 1
+
+    self.assertFalse(run_dpkg_configure())
+
+  # 異常系: dpkg --configure -a の実行が例外を発生させる
+  @patch("src.linux.update_apt_softwares.logger")
+  @patch("os.system")
+  def test_run_dpkg_configure_exception(self, mock_system, mock_logger):
+    mock_system.side_effect = Exception("dpkg configure failed")
+
+    self.assertFalse(run_dpkg_configure())
+    mock_logger.error.assert_called_once()
 
   def test_is_installed_version(self):
     self.assertFalse(_is_installed_version(None))

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -180,6 +180,84 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     self.assertFalse(result)
     mock_system.assert_called_once_with("apt-get -y dist-upgrade")
 
+  # 正常系: dpkgが中断状態でない場合、run_dpkg_configure()は呼ばれず既存フローが継続する
+  @patch("src.linux.update_apt_softwares.run_apt_update")
+  @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
+  @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")
+  @patch("src.linux.update_apt_softwares.run_dpkg_configure")
+  @patch("src.linux.update_apt_softwares.is_dpkg_broken", return_value=False)
+  @patch("src.linux.update_apt_softwares.is_root", return_value=True)
+  @patch("src.linux.update_apt_softwares.logger")
+  @patch("src.linux.update_apt_softwares.GitHubIssue")
+  def test_run_dpkg_not_broken(self, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+    mock_issue_instance = MagicMock()
+    mock_github_issue.return_value = mock_issue_instance
+    mock_run_apt_update.return_value = MagicMock()
+    mock_get_apt_full_upgrade_target.return_value = (MagicMock(), [], [], [])
+    mock_run_apt_full_upgrade.return_value = True
+
+    from src.linux.update_apt_softwares import run
+    run(mock_issue_instance, "test-host")
+
+    mock_is_dpkg_broken.assert_called_once()
+    mock_run_dpkg_configure.assert_not_called()
+    mock_issue_instance.comment.assert_not_called()
+    mock_run_apt_update.assert_called()
+
+  # 正常系: dpkgが中断状態で修復に成功した場合、コメントを追加して既存フローが継続する
+  @patch("src.linux.update_apt_softwares.run_apt_update")
+  @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
+  @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")
+  @patch("src.linux.update_apt_softwares.run_dpkg_configure", return_value=True)
+  @patch("src.linux.update_apt_softwares.is_dpkg_broken", return_value=True)
+  @patch("src.linux.update_apt_softwares.is_root", return_value=True)
+  @patch("src.linux.update_apt_softwares.logger")
+  @patch("src.linux.update_apt_softwares.GitHubIssue")
+  def test_run_dpkg_broken_configure_success(self, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+    mock_issue_instance = MagicMock()
+    mock_github_issue.return_value = mock_issue_instance
+    mock_issue_instance.get_markdown_computer_name.return_value = "test-host"
+    mock_run_apt_update.return_value = MagicMock()
+    mock_get_apt_full_upgrade_target.return_value = (MagicMock(), [], [], [])
+    mock_run_apt_full_upgrade.return_value = True
+
+    from src.linux.update_apt_softwares import run
+    run(mock_issue_instance, "test-host")
+
+    mock_run_dpkg_configure.assert_called_once()
+    mock_issue_instance.comment.assert_called_once()
+    mock_run_apt_update.assert_called()
+
+  # 異常系: dpkgが中断状態で修復に失敗した場合、failedで即時中断する
+  @patch("src.linux.update_apt_softwares.run_apt_update")
+  @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
+  @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")
+  @patch("src.linux.update_apt_softwares.run_dpkg_configure", return_value=False)
+  @patch("src.linux.update_apt_softwares.is_dpkg_broken", return_value=True)
+  @patch("src.linux.update_apt_softwares.is_root", return_value=True)
+  @patch("src.linux.update_apt_softwares.logger")
+  @patch("src.linux.update_apt_softwares.GitHubIssue")
+  def test_run_dpkg_broken_configure_failure(self, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+    mock_issue_instance = MagicMock()
+    mock_github_issue.return_value = mock_issue_instance
+    mock_issue_instance.get_markdown_computer_name.return_value = "test-host"
+
+    from src.linux.update_apt_softwares import run
+    run(mock_issue_instance, "test-host")
+
+    mock_run_dpkg_configure.assert_called_once()
+    mock_issue_instance.comment.assert_called_once()
+    mock_run_apt_update.assert_not_called()
+
+    last_call = mock_issue_instance.atomic_update_with_retry.call_args_list[-1]
+    self.assertEqual(last_call.kwargs["computer_name"], "test-host")
+    self.assertEqual(last_call.kwargs["package_manager"], "apt")
+    self.assertEqual(last_call.kwargs["upgraded"], "")
+    self.assertEqual(last_call.kwargs["failed"], "1")
+    self.assertEqual(last_call.kwargs["status"], "failed")
+    self.assertIn("os_eol", last_call.kwargs)
+    self.assertIn("os_eol_critical", last_call.kwargs)
+
   # 正常系: run関数のテスト
   @patch("src.linux.update_apt_softwares.run_apt_update")
   @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -189,7 +189,8 @@ class TestUpdateAptSoftwares(unittest.TestCase):
   @patch("src.linux.update_apt_softwares.is_root", return_value=True)
   @patch("src.linux.update_apt_softwares.logger")
   @patch("src.linux.update_apt_softwares.GitHubIssue")
-  def test_run_dpkg_not_broken(self, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+  @patch("src.linux.update_apt_softwares.get_os_eol_info", return_value=("不明", False))
+  def test_run_dpkg_not_broken(self, mock_get_os_eol_info, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
     mock_issue_instance = MagicMock()
     mock_github_issue.return_value = mock_issue_instance
     mock_run_apt_update.return_value = MagicMock()
@@ -213,7 +214,8 @@ class TestUpdateAptSoftwares(unittest.TestCase):
   @patch("src.linux.update_apt_softwares.is_root", return_value=True)
   @patch("src.linux.update_apt_softwares.logger")
   @patch("src.linux.update_apt_softwares.GitHubIssue")
-  def test_run_dpkg_broken_configure_success(self, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+  @patch("src.linux.update_apt_softwares.get_os_eol_info", return_value=("不明", False))
+  def test_run_dpkg_broken_configure_success(self, mock_get_os_eol_info, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
     mock_issue_instance = MagicMock()
     mock_github_issue.return_value = mock_issue_instance
     mock_issue_instance.get_markdown_computer_name.return_value = "test-host"
@@ -240,7 +242,8 @@ class TestUpdateAptSoftwares(unittest.TestCase):
   @patch("src.linux.update_apt_softwares.is_root", return_value=True)
   @patch("src.linux.update_apt_softwares.logger")
   @patch("src.linux.update_apt_softwares.GitHubIssue")
-  def test_run_dpkg_broken_configure_failure(self, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+  @patch("src.linux.update_apt_softwares.get_os_eol_info", return_value=("不明", False))
+  def test_run_dpkg_broken_configure_failure(self, mock_get_os_eol_info, mock_github_issue, mock_logger, mock_is_root, mock_is_dpkg_broken, mock_run_dpkg_configure, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
     mock_issue_instance = MagicMock()
     mock_github_issue.return_value = mock_issue_instance
     mock_issue_instance.get_markdown_computer_name.return_value = "test-host"
@@ -316,6 +319,7 @@ class TestUpdateAptSoftwares(unittest.TestCase):
   @patch("subprocess.run")
   def test_is_dpkg_broken_false(self, mock_run):
     mock_result = MagicMock()
+    mock_result.returncode = 0
     mock_result.stdout = ""
     mock_run.return_value = mock_result
 
@@ -330,6 +334,7 @@ class TestUpdateAptSoftwares(unittest.TestCase):
   @patch("subprocess.run")
   def test_is_dpkg_broken_true(self, mock_run):
     mock_result = MagicMock()
+    mock_result.returncode = 0
     mock_result.stdout = "libfoo:\n Package is in a very bad inconsistent state.\n"
     mock_run.return_value = mock_result
 
@@ -340,6 +345,18 @@ class TestUpdateAptSoftwares(unittest.TestCase):
   @patch("subprocess.run")
   def test_is_dpkg_broken_command_error(self, mock_run, mock_logger):
     mock_run.side_effect = OSError("dpkg not found")
+
+    self.assertFalse(is_dpkg_broken())
+    mock_logger.warning.assert_called_once()
+
+  # 異常系: dpkg --audit が非 0 の終了コードで終了する (実行自体の失敗)
+  @patch("src.linux.update_apt_softwares.logger")
+  @patch("subprocess.run")
+  def test_is_dpkg_broken_non_zero_returncode(self, mock_run, mock_logger):
+    mock_result = MagicMock()
+    mock_result.returncode = 2
+    mock_result.stdout = "libfoo:\n Package is in a very bad inconsistent state.\n"
+    mock_run.return_value = mock_result
 
     self.assertFalse(is_dpkg_broken())
     mock_logger.warning.assert_called_once()

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -180,7 +180,7 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     self.assertFalse(result)
     mock_system.assert_called_once_with("apt-get -y dist-upgrade")
 
-  # 正常系: dpkgが中断状態でない場合、run_dpkg_configure()は呼ばれず既存フローが継続する
+  # 正常系: dpkg が中断状態でない場合、run_dpkg_configure() は呼ばれず既存フローが継続する
   @patch("src.linux.update_apt_softwares.run_apt_update")
   @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
   @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")
@@ -204,7 +204,7 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     mock_issue_instance.comment.assert_not_called()
     mock_run_apt_update.assert_called()
 
-  # 正常系: dpkgが中断状態で修復に成功した場合、コメントを追加して既存フローが継続する
+  # 正常系: dpkg が中断状態で修復に成功した場合、コメントを追加して既存フローが継続する
   @patch("src.linux.update_apt_softwares.run_apt_update")
   @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
   @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")
@@ -228,7 +228,7 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     mock_issue_instance.comment.assert_called_once()
     mock_run_apt_update.assert_called()
 
-  # 異常系: dpkgが中断状態で修復に失敗した場合、failedで即時中断する
+  # 異常系: dpkg が中断状態で修復に失敗した場合、failed で即時中断する
   @patch("src.linux.update_apt_softwares.run_apt_update")
   @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
   @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -225,7 +225,10 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     run(mock_issue_instance, "test-host")
 
     mock_run_dpkg_configure.assert_called_once()
-    mock_issue_instance.comment.assert_called_once()
+    mock_issue_instance.get_markdown_computer_name.assert_called_with("test-host")
+    mock_issue_instance.comment.assert_called_once_with(
+      "test-host : dpkg の中断状態を検出したため `dpkg --configure -a` を実行しました。"
+    )
     mock_run_apt_update.assert_called()
 
   # 異常系: dpkg が中断状態で修復に失敗した場合、failed で即時中断する
@@ -246,7 +249,10 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     run(mock_issue_instance, "test-host")
 
     mock_run_dpkg_configure.assert_called_once()
-    mock_issue_instance.comment.assert_called_once()
+    mock_issue_instance.get_markdown_computer_name.assert_called_with("test-host")
+    mock_issue_instance.comment.assert_called_once_with(
+      "test-host : dpkg の中断状態を検出し `dpkg --configure -a` を実行しましたが失敗しました。手動対応が必要です。"
+    )
     mock_run_apt_update.assert_not_called()
 
     last_call = mock_issue_instance.atomic_update_with_retry.call_args_list[-1]

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 from subprocess import CalledProcessError
 import os
 
-from src.linux.update_apt_softwares import is_root, run_apt_update, get_apt_full_upgrade_target, run_apt_full_upgrade, _is_installed_version
+from src.linux.update_apt_softwares import is_root, run_apt_update, get_apt_full_upgrade_target, run_apt_full_upgrade, _is_installed_version, is_dpkg_broken
 
 class TestUpdateAptSoftwares(unittest.TestCase):
   # 正常系: root権限での実行確認
@@ -227,6 +227,38 @@ class TestUpdateAptSoftwares(unittest.TestCase):
 
     # アサーション
     mock_logger.error.assert_called_with("An error occurred during the upgrade: Update failed")
+
+  # 正常系: dpkg --audit の出力が空 (中断状態でない)
+  @patch("subprocess.run")
+  def test_is_dpkg_broken_false(self, mock_run):
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_run.return_value = mock_result
+
+    self.assertFalse(is_dpkg_broken())
+    mock_run.assert_called_once_with(
+      ["dpkg", "--audit"],
+      text=True,
+      capture_output=True,
+    )
+
+  # 異常系: dpkg --audit の出力が非空 (中断状態)
+  @patch("subprocess.run")
+  def test_is_dpkg_broken_true(self, mock_run):
+    mock_result = MagicMock()
+    mock_result.stdout = "libfoo:\n Package is in a very bad inconsistent state.\n"
+    mock_run.return_value = mock_result
+
+    self.assertTrue(is_dpkg_broken())
+
+  # 異常系: dpkg --audit の実行自体が失敗する
+  @patch("src.linux.update_apt_softwares.logger")
+  @patch("subprocess.run")
+  def test_is_dpkg_broken_command_error(self, mock_run, mock_logger):
+    mock_run.side_effect = OSError("dpkg not found")
+
+    self.assertFalse(is_dpkg_broken())
+    mock_logger.warning.assert_called_once()
 
   def test_is_installed_version(self):
     self.assertFalse(_is_installed_version(None))


### PR DESCRIPTION
## 概要

Issue #67 への対応です。Linux (apt) パッケージ更新処理 (`src/linux/update_apt_softwares.py`) において、dpkg が中断状態 (`dpkg --configure -a` の実行が必要な状態) の場合を検出し、必要に応じて自動的に `dpkg --configure -a` を実行するようにしました。

## 変更内容

- `is_dpkg_broken()`: `dpkg --audit` の標準出力の有無で中断状態を判定する関数を追加
  - `dpkg --audit` は破損パッケージが存在しなくても終了コード 0 を返すため、`check=True` は使わず stdout の有無で判定
  - コマンド自体が失敗した場合 (`OSError`) は warning ログを出力し `False` を返し、apt 更新処理本体を止めない
- `run_dpkg_configure()`: `dpkg --configure -a` を実行し、修復を試みる関数を追加
  - 既存の `run_apt_full_upgrade()` と同じ実装スタイル (`os.system` + 例外握り + bool 返却)
- `run()`: 上記 2 関数を `status="running"` 更新後・`run_apt_update()` 呼び出し前に組み込み
  - 中断状態でなければ何もせず既存フローを継続
  - 中断状態を検出し修復に成功した場合は info ログ + Issue コメントを追加して継続
  - 修復に失敗した場合は error ログ + Issue コメントを追加し、`status="failed"` を設定して即時中断
- テスト: 上記 3 パターン (未検出/検出→成功/検出→失敗) を含む新規テスト 9 件を追加

## テスト結果

`pytest tests/` : 98 passed, 1 skipped (既存の Windows 専用テストで無関係)

## 関連ドキュメント

Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/6029518/Spec+-+Issue+67+dpkg+configure+-a
Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/5963905/Plan+-+Issue+67+dpkg+configure+-a

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)