### PR TITLE
feat: 実行時にOS欄の値を更新するようにする

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -109,7 +109,7 @@ class GitHubIssue:
 
     return False
 
-  def atomic_update_with_retry(self, computer_name, package_manager, status, upgraded, failed, os_eol=None, os_eol_critical=False, operation_system=None, max_retries=3):
+  def atomic_update_with_retry(self, computer_name, package_manager, status, upgraded, failed, os_eol=None, os_eol_critical=False, max_retries=3, operation_system=None):
     """
     Atomically update the issue body with retry logic to handle concurrent updates.
     This method combines update processing and GitHub Issue body reflection into a single operation.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -83,7 +83,7 @@ class GitHubIssue:
         markdown["failed"]
       ]) + " |"
 
-  def update_software_update_row(self, computer_name, package_manager, status, upgraded, failed, os_eol=None, os_eol_critical=False):
+  def update_software_update_row(self, computer_name, package_manager, status, upgraded, failed, os_eol=None, os_eol_critical=False, operation_system=None):
     if status not in self.status_mapping:
       raise Exception(f"Invalid status: {status}. Valid values are {list(self.status_mapping.keys())}")
 
@@ -94,18 +94,22 @@ class GitHubIssue:
         software_update["markdown"]["checkmark"] = checkmark
         software_update["markdown"]["upgraded"] = upgraded
         software_update["markdown"]["failed"] = failed
-        
+
         # OS EOL 情報がある場合は更新
         if os_eol is not None:
           software_update["markdown"]["os_eol"] = os_eol
-        
+
+        # OS 名・バージョン情報がある場合は更新
+        if operation_system is not None:
+          software_update["markdown"]["operation_system"] = operation_system
+
         software_update["markdown"]["raw"] = self._build_markdown_row(software_update)
 
         return True
 
     return False
 
-  def atomic_update_with_retry(self, computer_name, package_manager, status, upgraded, failed, os_eol=None, os_eol_critical=False, max_retries=3):
+  def atomic_update_with_retry(self, computer_name, package_manager, status, upgraded, failed, os_eol=None, os_eol_critical=False, operation_system=None, max_retries=3):
     """
     Atomically update the issue body with retry logic to handle concurrent updates.
     This method combines update processing and GitHub Issue body reflection into a single operation.
@@ -132,7 +136,11 @@ class GitHubIssue:
             # OS EOL 情報がある場合は更新
             if os_eol is not None:
               software_update["markdown"]["os_eol"] = os_eol
-            
+
+            # OS 名・バージョン情報がある場合は更新
+            if operation_system is not None:
+              software_update["markdown"]["operation_system"] = operation_system
+
             software_update["markdown"]["raw"] = self._build_markdown_row(software_update)
             updated = True
             break

--- a/src/linux/update_apt_softwares.py
+++ b/src/linux/update_apt_softwares.py
@@ -5,7 +5,7 @@ import textwrap
 import time
 import logging
 from .. import GitHubIssue # required by tests
-from ..os_eol import get_os_eol_info
+from ..os_eol import get_os_eol_info, get_os_display_string
 
 from .. import is_root
 
@@ -214,7 +214,9 @@ def run(github_issue, hostname):
   try:
     # OS EOL 情報を取得
     os_eol_info, is_critical = get_os_eol_info()
-        
+    # OS 表示文字列を取得
+    os_display = get_os_display_string()
+
     logger.info("Starting apt update and full upgrade...")
     # Set initial status to running
     github_issue.atomic_update_with_retry(
@@ -225,6 +227,7 @@ def run(github_issue, hostname):
       status="running",
       os_eol=os_eol_info,
       os_eol_critical=is_critical,
+      operation_system=os_display,
     )
 
     logger.info("Updating package list...")
@@ -244,6 +247,7 @@ def run(github_issue, hostname):
         status="success",
         os_eol=os_eol_info,
         os_eol_critical=is_critical,
+        operation_system=os_display,
       )
       return
 
@@ -258,6 +262,7 @@ def run(github_issue, hostname):
       status="running",
       os_eol=os_eol_info,
       os_eol_critical=is_critical,
+      operation_system=os_display,
     )
 
     logger.info("Upgrading packages...")
@@ -282,6 +287,7 @@ def run(github_issue, hostname):
       status=final_status,
       os_eol=os_eol_info,
       os_eol_critical=is_critical,
+      operation_system=os_display,
     )
 
     logger.info("Upgrade complete.")
@@ -299,7 +305,9 @@ def run(github_issue, hostname):
     except Exception:
       os_eol_info = "不明"
       is_critical = False
-        
+    # OS 表示文字列を取得 (エラー時も含める)
+    os_display = get_os_display_string()
+
     # Set error status atomically
     github_issue.atomic_update_with_retry(
       computer_name=hostname,
@@ -309,4 +317,5 @@ def run(github_issue, hostname):
       status="failed",
       os_eol=os_eol_info,
       os_eol_critical=is_critical,
+      operation_system=os_display,
     )

--- a/src/os_eol.py
+++ b/src/os_eol.py
@@ -311,3 +311,42 @@ def get_os_eol_info() -> Tuple[str, bool]:
   os_name, version = get_os_version_info()
   eol_date = get_os_eol_date(os_name, version)
   return format_eol_info(eol_date)
+
+
+def get_os_display_string() -> str:
+  """
+  「OS」列に表示するための OS 名・バージョン文字列を取得する
+
+  Linux の場合は /etc/os-release の PRETTY_NAME をそのまま返す。
+  取得できない場合や Windows の場合は、get_linux_version_info() /
+  get_windows_version_info() が返す (os_name, version) を
+  "{os_name} {version}" 形式に整形して返す。
+
+  Returns:
+    str: OS 表示文字列。取得に失敗した場合は "Unknown"
+  """
+  try:
+    if os.name == 'nt':
+      os_name, version = get_windows_version_info()
+      return f"{os_name} {version}"
+
+    # Linux: /etc/os-release の PRETTY_NAME を優先する
+    if os.path.exists('/etc/os-release'):
+      with open('/etc/os-release', 'r') as f:
+        lines = f.readlines()
+
+      os_info = {}
+      for line in lines:
+        if '=' in line:
+          key, value = line.strip().split('=', 1)
+          os_info[key] = value.strip('"')
+
+      pretty_name = os_info.get('PRETTY_NAME', '')
+      if pretty_name:
+        return pretty_name
+
+    # PRETTY_NAME が取得できない場合は既存の (os_name, version) を整形する
+    os_name, version = get_linux_version_info()
+    return f"{os_name} {version}"
+  except Exception:
+    return "Unknown"

--- a/src/windows/update_scoop_softwares.py
+++ b/src/windows/update_scoop_softwares.py
@@ -10,7 +10,7 @@ import json
 import psutil
 import traceback
 
-from ..os_eol import get_os_eol_info
+from ..os_eol import get_os_eol_info, get_os_display_string
 
 def update_scoop_repos():
   # Scoop update を実行し、リポジトリを更新する
@@ -323,7 +323,9 @@ def run(github_issue, hostname) -> None:
     try:
         # OS EOL 情報を取得
         os_eol_info, is_critical = get_os_eol_info()
-        
+        # OS 表示文字列を取得
+        os_display = get_os_display_string()
+
         # Set initial status to running
         github_issue.atomic_update_with_retry(
             computer_name=hostname,
@@ -333,6 +335,7 @@ def run(github_issue, hostname) -> None:
             status="running",
             os_eol=os_eol_info,
             os_eol_critical=is_critical,
+            operation_system=os_display,
         )
 
         update_scoop_repos()
@@ -356,6 +359,7 @@ def run(github_issue, hostname) -> None:
             status="running",
             os_eol=os_eol_info,
             os_eol_critical=is_critical,
+            operation_system=os_display,
         )
 
         print("Updating not running applications...")
@@ -388,6 +392,7 @@ def run(github_issue, hostname) -> None:
             status=status,
             os_eol=os_eol_info,
             os_eol_critical=is_critical,
+            operation_system=os_display,
         )
 
         # scoop のクリーンアップを実行
@@ -408,7 +413,9 @@ def run(github_issue, hostname) -> None:
         except Exception:
             os_eol_info = "不明"
             is_critical = False
-        
+        # OS 表示文字列を取得 (エラー時も含める)
+        os_display = get_os_display_string()
+
         # Set error status atomically
         github_issue.atomic_update_with_retry(
             computer_name=hostname,
@@ -418,4 +425,5 @@ def run(github_issue, hostname) -> None:
             status="failed",
             os_eol=os_eol_info,
             os_eol_critical=is_critical,
+            operation_system=os_display,
         )

--- a/tests/linux/test_update_apt_softwares.py
+++ b/tests/linux/test_update_apt_softwares.py
@@ -181,13 +181,14 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     mock_system.assert_called_once_with("apt-get -y dist-upgrade")
 
   # 正常系: run関数のテスト
+  @patch("src.linux.update_apt_softwares.get_os_display_string", return_value="Ubuntu 22.04.5 LTS")
   @patch("src.linux.update_apt_softwares.run_apt_update")
   @patch("src.linux.update_apt_softwares.get_apt_full_upgrade_target")
   @patch("src.linux.update_apt_softwares.run_apt_full_upgrade")
   @patch("src.linux.update_apt_softwares.is_root", return_value=True)
   @patch("src.linux.update_apt_softwares.logger")
   @patch("src.linux.update_apt_softwares.GitHubIssue")
-  def test_run_success(self, mock_github_issue, mock_logger, mock_is_root, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update):
+  def test_run_success(self, mock_github_issue, mock_logger, mock_is_root, mock_run_apt_full_upgrade, mock_get_apt_full_upgrade_target, mock_run_apt_update, mock_get_os_display_string):
     # モックの設定
     mock_issue_instance = MagicMock()
     mock_github_issue.return_value = mock_issue_instance
@@ -202,6 +203,9 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     # アサーション
     mock_logger.info.assert_called()  # ログが出力されていることを確認
     mock_issue_instance.atomic_update_with_retry.assert_called()  # GitHubIssueの原子的更新が呼ばれていることを確認
+    # operation_system が全呼び出しに渡されていることを確認
+    for call_args in mock_issue_instance.atomic_update_with_retry.call_args_list:
+      self.assertEqual(call_args.kwargs["operation_system"], "Ubuntu 22.04.5 LTS")
 
   # 異常系: root権限がない場合
   @patch("src.linux.update_apt_softwares.is_root", return_value=False)
@@ -214,11 +218,12 @@ class TestUpdateAptSoftwares(unittest.TestCase):
     mock_logger.error.assert_called_with("This script must be run as root.")
 
   # 修正: test_run_apt_update_exceptionでgithub_issueをモックとして渡す
+  @patch("src.linux.update_apt_softwares.get_os_display_string", return_value="Ubuntu 22.04.5 LTS")
   @patch("src.linux.update_apt_softwares.run_apt_update", side_effect=Exception("Update failed"))
   @patch("src.linux.update_apt_softwares.is_root", return_value=True)
   @patch("src.linux.update_apt_softwares.logger")
   @patch("src.linux.update_apt_softwares.GitHubIssue")
-  def test_run_apt_update_exception(self, mock_github_issue, mock_logger, mock_is_root, mock_run_apt_update):
+  def test_run_apt_update_exception(self, mock_github_issue, mock_logger, mock_is_root, mock_run_apt_update, mock_get_os_display_string):
     mock_issue_instance = MagicMock()
     mock_github_issue.return_value = mock_issue_instance
 
@@ -227,6 +232,9 @@ class TestUpdateAptSoftwares(unittest.TestCase):
 
     # アサーション
     mock_logger.error.assert_called_with("An error occurred during the upgrade: Update failed")
+    # 例外系でも operation_system が渡されていることを確認
+    call_args = mock_issue_instance.atomic_update_with_retry.call_args
+    self.assertEqual(call_args.kwargs["operation_system"], "Ubuntu 22.04.5 LTS")
 
   def test_is_installed_version(self):
     self.assertFalse(_is_installed_version(None))

--- a/tests/test_github_issue_atomic.py
+++ b/tests/test_github_issue_atomic.py
@@ -69,6 +69,126 @@ class TestGitHubIssueAtomic(unittest.TestCase):
 
   @patch('src.requests.patch')
   @patch('src.requests.get')
+  def test_atomic_update_with_retry_overwrites_operation_system(self, mock_get, mock_patch):
+    """operation_system を渡した場合に OS 列が上書きされることを確認するテスト"""
+    initial_body = "| ⏳ | Computer1 | Linux | apt | 0 | 0 | <!-- update-softwares#Computer1#apt -->"
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.json.return_value = {"body": initial_body}
+    mock_get.return_value = mock_get_response
+
+    mock_patch_response = MagicMock()
+    mock_patch_response.status_code = 200
+    mock_patch.return_value = mock_patch_response
+
+    github_issue = GitHubIssue(self.repo_name, self.issue_number, self.github_token)
+
+    result = github_issue.atomic_update_with_retry(
+      computer_name="Computer1",
+      package_manager="apt",
+      status="success",
+      upgraded="5",
+      failed="0",
+      operation_system="Ubuntu 22.04.5 LTS",
+    )
+
+    self.assertTrue(result)
+    patch_call_args = mock_patch.call_args
+    updated_body = patch_call_args[1]['json']['body']
+    self.assertIn("Ubuntu 22.04.5 LTS", updated_body)
+    self.assertNotIn("| Linux |", updated_body)
+
+  @patch('src.requests.patch')
+  @patch('src.requests.get')
+  def test_atomic_update_with_retry_keeps_operation_system_when_none(self, mock_get, mock_patch):
+    """operation_system を渡さない場合、既存の OS 列の値が維持されることを確認するテスト"""
+    initial_body = "| ⏳ | Computer1 | Linux | apt | 0 | 0 | <!-- update-softwares#Computer1#apt -->"
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.json.return_value = {"body": initial_body}
+    mock_get.return_value = mock_get_response
+
+    mock_patch_response = MagicMock()
+    mock_patch_response.status_code = 200
+    mock_patch.return_value = mock_patch_response
+
+    github_issue = GitHubIssue(self.repo_name, self.issue_number, self.github_token)
+
+    github_issue.atomic_update_with_retry(
+      computer_name="Computer1",
+      package_manager="apt",
+      status="success",
+      upgraded="5",
+      failed="0",
+    )
+
+    updated_body = mock_patch.call_args[1]['json']['body']
+    self.assertIn("| Linux |", updated_body)
+
+  @patch('src.requests.get')
+  def test_update_software_update_row_overwrites_operation_system(self, mock_get):
+    """update_software_update_row() で operation_system が上書きされることを確認するテスト"""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+      "body": "| ⏳ | Computer1 | Linux | apt | 0 | 0 | <!-- update-softwares#Computer1#apt -->"
+    }
+    mock_get.return_value = mock_response
+
+    github_issue = GitHubIssue(self.repo_name, self.issue_number, self.github_token)
+
+    result = github_issue.update_software_update_row(
+      computer_name="Computer1",
+      package_manager="apt",
+      status="success",
+      upgraded="5",
+      failed="0",
+      operation_system="Ubuntu 22.04.5 LTS",
+    )
+
+    self.assertTrue(result)
+    updated_row = next(
+      su for su in github_issue.software_updates
+      if su["computer_name"] == "Computer1" and su["package_manager"] == "apt"
+    )
+    self.assertEqual(updated_row["markdown"]["operation_system"], "Ubuntu 22.04.5 LTS")
+    self.assertIn("Ubuntu 22.04.5 LTS", updated_row["markdown"]["raw"])
+
+  @patch('src.requests.patch')
+  @patch('src.requests.get')
+  def test_atomic_update_with_retry_overwrites_operation_system_new_format(self, mock_get, mock_patch):
+    """新フォーマット(os_eol 列あり)の行でも operation_system が上書きされることを確認するテスト"""
+    initial_body = "| ⏳ | Computer1 | Linux | apt | 0 | 0 | 不明 | <!-- update-softwares#Computer1#apt -->"
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.json.return_value = {"body": initial_body}
+    mock_get.return_value = mock_get_response
+
+    mock_patch_response = MagicMock()
+    mock_patch_response.status_code = 200
+    mock_patch.return_value = mock_patch_response
+
+    github_issue = GitHubIssue(self.repo_name, self.issue_number, self.github_token)
+
+    github_issue.atomic_update_with_retry(
+      computer_name="Computer1",
+      package_manager="apt",
+      status="success",
+      upgraded="5",
+      failed="0",
+      os_eol="2027-04-30 (300 日後)",
+      operation_system="Ubuntu 22.04.5 LTS",
+    )
+
+    updated_body = mock_patch.call_args[1]['json']['body']
+    self.assertIn("Ubuntu 22.04.5 LTS", updated_body)
+    self.assertIn("2027-04-30", updated_body)
+
+  @patch('src.requests.patch')
+  @patch('src.requests.get')
   def test_atomic_update_with_retry_on_failure(self, mock_get, mock_patch):
     """Test atomic update with retry on API failure."""
     # Setup initial issue body

--- a/tests/test_os_eol.py
+++ b/tests/test_os_eol.py
@@ -9,7 +9,8 @@ from src.os_eol import (
   get_os_eol_date,
   get_os_eol_date_from_api,
   format_eol_info,
-  get_os_eol_info
+  get_os_eol_info,
+  get_os_display_string
 )
 
 
@@ -335,6 +336,60 @@ class TestOSEOL(unittest.TestCase):
         
     self.assertEqual(os_name, "CentOS")
     self.assertEqual(version, "7")
+
+  @patch('os.name', 'posix')
+  @patch('os.path.exists')
+  @patch('builtins.open', mock_open(read_data='NAME="Ubuntu"\nVERSION_ID="22.04"\nPRETTY_NAME="Ubuntu 22.04.5 LTS"\n'))
+  def test_get_os_display_string_linux_pretty_name(self, mock_exists):
+    """Linux で PRETTY_NAME が取得できる場合、そのまま返すテスト"""
+    mock_exists.return_value = True
+
+    result = get_os_display_string()
+
+    self.assertEqual(result, "Ubuntu 22.04.5 LTS")
+
+  @patch('os.name', 'posix')
+  @patch('os.path.exists')
+  @patch('src.os_eol.get_linux_version_info')
+  def test_get_os_display_string_linux_no_os_release(self, mock_get_version, mock_exists):
+    """/etc/os-release が存在しない場合、(os_name, version) にフォールバックするテスト"""
+    mock_exists.return_value = False
+    mock_get_version.return_value = ("Ubuntu", "22.04")
+
+    result = get_os_display_string()
+
+    self.assertEqual(result, "Ubuntu 22.04")
+
+  @patch('os.name', 'posix')
+  @patch('os.path.exists')
+  @patch('builtins.open', mock_open(read_data='NAME="Ubuntu"\nVERSION_ID="22.04"\n'))
+  @patch('src.os_eol.get_linux_version_info')
+  def test_get_os_display_string_linux_no_pretty_name(self, mock_get_version, mock_exists):
+    """/etc/os-release に PRETTY_NAME がない場合、(os_name, version) にフォールバックするテスト"""
+    mock_exists.return_value = True
+    mock_get_version.return_value = ("Ubuntu", "22.04")
+
+    result = get_os_display_string()
+
+    self.assertEqual(result, "Ubuntu 22.04")
+
+  @patch('os.name', 'nt')
+  @patch('src.os_eol.get_windows_version_info')
+  def test_get_os_display_string_windows(self, mock_get_version):
+    """Windows の場合、(os_name, version) を結合して返すテスト"""
+    mock_get_version.return_value = ("Windows", "11-24H2")
+
+    result = get_os_display_string()
+
+    self.assertEqual(result, "Windows 11-24H2")
+
+  @patch('os.name', 'posix')
+  @patch('os.path.exists', side_effect=Exception("boom"))
+  def test_get_os_display_string_exception_fallback(self, mock_exists):
+    """例外発生時に Unknown を返すテスト"""
+    result = get_os_display_string()
+
+    self.assertEqual(result, "Unknown")
 
 
 if __name__ == "__main__":

--- a/tests/windows/test_update_scoop_softwares.py
+++ b/tests/windows/test_update_scoop_softwares.py
@@ -15,6 +15,7 @@ from src.windows.update_scoop_softwares import (
   start_app,
   get_app_startup_command,
   cleanup_scoop,
+  run,
 )
 
 
@@ -361,6 +362,40 @@ class TestUpdateScoopSoftwares(unittest.TestCase):
     result = cleanup_scoop()
     self.assertFalse(result)
     self.assertEqual(mock_run.call_count, 2)
+
+  @patch('src.windows.update_scoop_softwares.get_os_display_string', return_value="Windows 11-24H2")
+  @patch('src.windows.update_scoop_softwares.get_os_eol_info', return_value=("2030-01-01 (1000 日後)", False))
+  @patch('src.windows.update_scoop_softwares.cleanup_scoop', return_value=True)
+  @patch('src.windows.update_scoop_softwares.get_running_apps', return_value={})
+  @patch('src.windows.update_scoop_softwares.get_scoop_status', return_value=[])
+  @patch('src.windows.update_scoop_softwares.update_scoop_repos', return_value=True)
+  def test_run_success_passes_operation_system(self, mock_update_repos, mock_get_status, mock_get_running_apps, mock_cleanup, mock_get_eol, mock_get_display):
+    """run() が operation_system を全呼び出しに渡すことを確認するテスト
+
+    `get_running_apps()` は `app_names` が空でも内部で `os.getenv("SCOOP")` を
+    無条件に呼び出すため、モックしないとテスト環境に `SCOOP` 環境変数がない場合に
+    `TypeError` が送出され、`run()` の except ブロック(異常系)に落ちて
+    しまい、意図した正常系を検証できなくなる。そのため明示的にモックする。
+    """
+    github_issue = MagicMock()
+
+    run(github_issue, "test-host")
+
+    github_issue.atomic_update_with_retry.assert_called()
+    for call_args in github_issue.atomic_update_with_retry.call_args_list:
+      self.assertEqual(call_args.kwargs["operation_system"], "Windows 11-24H2")
+
+  @patch('src.windows.update_scoop_softwares.get_os_display_string', return_value="Windows 11-24H2")
+  @patch('src.windows.update_scoop_softwares.get_os_eol_info', side_effect=Exception("boom"))
+  @patch('src.windows.update_scoop_softwares.update_scoop_repos', side_effect=Exception("update failed"))
+  def test_run_exception_passes_operation_system(self, mock_update_repos, mock_get_eol, mock_get_display):
+    """run() の例外系でも operation_system が渡されることを確認するテスト"""
+    github_issue = MagicMock()
+
+    run(github_issue, "test-host")
+
+    call_args = github_issue.atomic_update_with_retry.call_args
+    self.assertEqual(call_args.kwargs["operation_system"], "Windows 11-24H2")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概要

Issue #66 対応。パッケージ更新実行時に、GitHub Issue のテーブルの「OS」列を実行環境の実際の OS 名・バージョンで上書きするようにしました。

## 変更内容

- `src/os_eol.py`: `get_os_display_string()` を新規追加。Linux では `/etc/os-release` の `PRETTY_NAME` を優先し、取得できない場合は `get_linux_version_info()` の `(os_name, version)` を整形して返す。Windows では `get_windows_version_info()` の値を整形して返す。例外時は `"Unknown"` を返す。
- `src/__init__.py`: `GitHubIssue.update_software_update_row()` / `atomic_update_with_retry()` に `operation_system=None` パラメータを追加。既存の `os_eol` と同様の条件付き上書きパターンで、OS 列を更新する。新旧フォーマット双方の行に対応。
- `src/linux/update_apt_softwares.py`: `run()` 内の全 `atomic_update_with_retry()` 呼び出し (正常系4箇所、異常系1箇所) に `operation_system` を渡すよう修正。
- `src/windows/update_scoop_softwares.py`: 同様に `run()` 内の全呼び出し (正常系3箇所、異常系1箇所) に `operation_system` を渡すよう修正。
- 上記変更に対応するユニットテストを追加。

## テスト

- `python3 -m pytest tests/` : 100 passed, 1 skipped
- `flake8 . --count --select=E1,E2,E3,E4,E7,E9,W1,W2,W3,W4,W5,F63,F7,F82` : master ブランチと比較して新規エラーなし

## 関連

Closes #66

Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/5898368
Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/6029537/Plan+-+Issue+66+OS