### PR TITLE
fix: drop Python 3.8/3.9 from Windows CI matrix, bump requests to 2.34.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,4 +33,4 @@ Linux (apt) と Windows (scoop) の複数マシンに対するパッケージ更
 
 ## 技術スタック
 
-Python 3.8-3.13 (CI で検証、推奨 3.12 以上) / pip。依存は `requirements.txt` にピン留め (`requests`, `psutil`)。テストは pytest (`pytest.ini` で slow / integration / unit マーカーを定義)、記述は標準 unittest。CI は GitHub Actions (Linux / Windows)。
+Python 3.10-3.13 (CI で検証、推奨 3.12 以上) / pip。依存は `requirements.txt` にピン留め (`requests`, `psutil`)。テストは pytest (`pytest.ini` で slow / integration / unit マーカーを定義)、記述は標準 unittest。CI は GitHub Actions (Linux / Windows)。

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.x"]
 
     steps:
       - name: Checkout code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.32.4
+requests==2.34.2
 psutil==7.2.2


### PR DESCRIPTION
## 概要

Renovate PR #57 (`requests` 2.32.4 -> 2.34.2) が Windows CI の Python 3.8 / 3.9 ジョブで失敗していた件の修正。

## 原因

`requests` は 2.32.5 で Python 3.8 サポートを、2.33.0 で Python 3.9 サポートをそれぞれ EOL 経過に伴い打ち切っている (`Requires-Python >=3.10`)。そのため `pip install -r requirements.txt` が Python 3.8 / 3.9 の CI ジョブでのみ `No matching distribution found for requests==2.34.2` で失敗する (3.10-3.13 / 3.x は影響なし)。Python 3.8 / 3.9 はいずれも既に上流 EOL 済み。

## 対応

- `requirements.txt`: `requests` を `2.34.2` に追随
- `.github/workflows/windows-ci.yml`: マトリクスから `3.8` / `3.9` を除外
- `.github/copilot-instructions.md`: 対応 Python バージョン記載を `3.10-3.13` に更新

ソースコード側の変更は不要 (3.10 以降限定の構文は未使用)。ローカルで `requests==2.34.2` を適用した状態で全 111 件のテスト (110 pass, 1 skip) を確認済み。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)